### PR TITLE
feat: migrate receipt splitter UI to Streamlit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ app/web/.vite/
 
 # Vite build output (run `npm run build` in app/web before Terraform pack)
 app/ec2/assets/
+
+.venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A web application for splitting grocery receipts among multiple people with flex
 ## Features
 
 ### Core functionality
+
 - **Multi-person support**: Add people to split receipts among
 - **Flexible splitting**:
   - Assign items to individual people
@@ -15,6 +16,7 @@ A web application for splitting grocery receipts among multiple people with flex
 - **CSV export** for Excel or accounting tools
 
 ### User experience
+
 - **Dynamic UI** for any number of people
 - **Custom split values** preserved when people are added or removed
 - **Validation** with clear feedback; invalid custom splits are called out in a banner and block CSV export until fixed
@@ -42,14 +44,17 @@ receipt_splitter/
 ## Technology stack
 
 - **Frontend**: React 19, TypeScript
+- **Python app**: Streamlit
 - **Build**: Vite 8
 - **Tests**: Vitest (core math and CSV in `app/web/src/lib/`)
+- **Python tests**: Pytest (`app/tests/`)
 - **Styling**: CSS (see `app/web/src/style.css`)
 - **Deploy**: Static files under `app/ec2/` are zipped by Terraform and served from EC2 via Python’s `http.server`
 
 ## User guide
 
 ### Getting started
+
 1. **Configure people** with the "+ Add Person" button
 2. **Add items** with description and cost
 3. **Expense To**: choose a person, "Split Evenly", or "Custom Split"
@@ -57,11 +62,13 @@ receipt_splitter/
 5. **Review** the summary and running total, then **Export to CSV** if needed
 
 ### Custom split
+
 - **Percent**: entries must total 100%
 - **Dollar**: entries must total the line cost
 - Invalid lines are excluded from group totals until fixed; export stays disabled until all custom splits are valid
 
 ### Keyboard
+
 - **Enter** on the **item description** field adds another item row (other fields do not)
 - **Tab** moves between fields as usual
 
@@ -77,11 +84,25 @@ npm run dev
 
 Open the URL Vite prints (usually `http://localhost:5173`).
 
+### Streamlit local development
+
+```bash
+cd app
+python3 -m pip install -r requirements.txt
+python3 -m streamlit run streamlit_app.py
+```
+
+Open the local Streamlit URL shown in the terminal (usually `http://localhost:8501`).
+
 ### Tests
 
 ```bash
 cd app/web
 npm run test
+```
+
+```bash
+python3 -m pytest app/tests
 ```
 
 ### Production build
@@ -106,6 +127,12 @@ Always run `npm run build` in `app/web` before `terraform apply` if the UI chang
 
 - **README.md** (this file): overview and workflows
 - **TECHNICAL_DOCS.md**: architecture and module layout
+
+## Streamlit migration notes
+
+- Streamlit implementation lives in `app/streamlit_app.py` and `app/streamlit_domain/`.
+- Domain calculations (split logic, rounding, CSV generation, running totals) are implemented in Python for parity with the React behavior.
+- React app under `app/web/` remains available for side-by-side validation during migration.
 
 ## License
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+pytest

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -27,51 +27,389 @@ def format_currency(value: float) -> str:
     return f"${value:.2f}"
 
 
+def inject_styles() -> None:
+    st.markdown(
+        """
+        <style>
+        :root {
+            --rs-text: #1f2937;
+            --rs-muted: #4b5563;
+            --rs-config-bg: #e3f2fd;
+            --rs-items-bg: #f8f9fa;
+            --rs-tax-bg: #e9ecef;
+            --rs-running-bg: #fff3cd;
+            --rs-banner-bg: #fff3cd;
+            --rs-banner-border: #ffc107;
+            --rs-banner-text: #856404;
+            --rs-summary-bg: #f8f9fa;
+            --rs-summary-accent: #007bff;
+            --rs-running-head-bg: #ffe08a;
+            --rs-running-head-text: #856404;
+            --rs-total-bg: #f1f5f9;
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --rs-text: #e5e7eb;
+                --rs-muted: #cbd5e1;
+                --rs-config-bg: #132a3a;
+                --rs-items-bg: #1f2937;
+                --rs-tax-bg: #2d3748;
+                --rs-running-bg: #3b2f13;
+                --rs-banner-bg: #4b3b14;
+                --rs-banner-border: #d9a300;
+                --rs-banner-text: #fde68a;
+                --rs-summary-bg: #1f2937;
+                --rs-summary-accent: #60a5fa;
+                --rs-running-head-bg: #5a4718;
+                --rs-running-head-text: #fde68a;
+                --rs-total-bg: #374151;
+            }
+        }
+        .rs-shell {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 8px;
+            color: var(--rs-text);
+        }
+        [class*="st-key-rs-shell"] {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 8px;
+            color: var(--rs-text);
+        }
+        .rs-section {
+            border-radius: 8px;
+            padding: 14px 16px;
+            margin: 12px 0;
+            border-left: 4px solid transparent;
+            color: var(--rs-text);
+        }
+        [class*="st-key-rs-config-section"],
+        [class*="st-key-rs-items-section"],
+        [class*="st-key-rs-tax-section"],
+        [class*="st-key-rs-running-section"],
+        [class*="st-key-rs-export-section"] {
+            border-radius: 8px;
+            padding: 14px 16px;
+            margin: 12px 0;
+            border-left: 4px solid transparent;
+            color: var(--rs-text);
+        }
+        .rs-config {
+            background: var(--rs-config-bg);
+            border-left-color: #2196f3;
+        }
+        [class*="st-key-rs-config-section"] {
+            background: var(--rs-config-bg);
+            border-left-color: #2196f3;
+        }
+        .rs-items {
+            background: var(--rs-items-bg);
+        }
+        [class*="st-key-rs-items-section"] {
+            background: var(--rs-items-bg);
+        }
+        .rs-tax {
+            background: var(--rs-tax-bg);
+        }
+        [class*="st-key-rs-tax-section"] {
+            background: var(--rs-tax-bg);
+        }
+        .rs-running {
+            background: var(--rs-running-bg);
+            border-left-color: #ffc107;
+        }
+        [class*="st-key-rs-running-section"] {
+            background: var(--rs-running-bg);
+            border-left-color: #ffc107;
+        }
+        .rs-export {
+            text-align: center;
+        }
+        [class*="st-key-rs-export-section"] {
+            text-align: center;
+        }
+        .rs-invalid-banner {
+            background: var(--rs-banner-bg);
+            border: 1px solid var(--rs-banner-border);
+            color: var(--rs-banner-text);
+            padding: 10px 12px;
+            border-radius: 8px;
+            margin: 6px 0 14px 0;
+            font-size: 14px;
+        }
+        .rs-summary-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 16px;
+            margin-top: 16px;
+        }
+        .rs-summary-card {
+            background: var(--rs-summary-bg);
+            border-left: 4px solid var(--rs-summary-accent);
+            border-radius: 8px;
+            padding: 14px;
+            color: var(--rs-text);
+        }
+        .rs-summary-card h4 {
+            margin: 0 0 10px 0;
+            color: var(--rs-summary-accent);
+            font-size: 18px;
+        }
+        .rs-summary-row {
+            display: flex;
+            justify-content: space-between;
+            margin: 6px 0;
+            font-size: 14px;
+            color: var(--rs-text);
+        }
+        .rs-summary-row-total {
+            border-top: 2px solid var(--rs-summary-accent);
+            margin-top: 10px;
+            padding-top: 8px;
+            font-weight: bold;
+            color: var(--rs-summary-accent);
+            font-size: 17px;
+        }
+        .rs-running-table-head {
+            font-weight: 600;
+            color: var(--rs-running-head-text);
+            background: var(--rs-running-head-bg);
+            border-radius: 6px;
+            padding: 6px 8px;
+            margin-bottom: 6px;
+        }
+        .rs-running-total-row {
+            background: var(--rs-total-bg);
+            border-radius: 6px;
+            padding: 6px 8px;
+            font-weight: 700;
+            color: var(--rs-text);
+        }
+        .rs-export-help {
+            color: var(--rs-muted);
+            font-size: 12px;
+            margin-top: 8px;
+        }
+        [class*="st-key-person-enter-submit-"] button,
+        [class*="st-key-item-enter-submit-"] button {
+            display: none !important;
+            height: 0 !important;
+            min-height: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
+            border: 0 !important;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def apply_pending_focus() -> None:
+    focus_key = st.session_state.get("pending_focus_key", "")
+    focus_mode = st.session_state.get("pending_focus_mode", "")
+    if not focus_key and not focus_mode:
+        return
+    script_html = f"""
+        <script>
+        (function() {{
+          const focusKey = {focus_key!r};
+          const focusMode = {focus_mode!r};
+          const rootDoc = (window.parent && window.parent.document) ? window.parent.document : document;
+          let tries = 0;
+          const maxTries = 36;
+
+          function pickTarget() {{
+            if (focusMode === "person") {{
+              const people = Array.from(
+                rootDoc.querySelectorAll('input[aria-label^="Person "], [class*="st-key-person-name-"] input')
+              );
+              if (people.length > 0) return people[people.length - 1];
+            }}
+            if (focusMode === "item") {{
+              const items = Array.from(
+                rootDoc.querySelectorAll('input[placeholder="Enter item name"], [class*="st-key-item-name-"] input')
+              );
+              if (items.length > 0) return items[items.length - 1];
+            }}
+            if (focusKey) {{
+              const keyed = rootDoc.querySelector('.st-key-' + focusKey + ' input');
+              if (keyed) return keyed;
+            }}
+            return null;
+          }}
+
+          const timer = setInterval(() => {{
+            const target = pickTarget();
+            if (target) {{
+              if (rootDoc.activeElement && rootDoc.activeElement !== target) {{
+                rootDoc.activeElement.blur?.();
+              }}
+              target.focus();
+              target.select?.();
+              clearInterval(timer);
+              return;
+            }}
+            tries += 1;
+            if (tries >= maxTries) {{
+              clearInterval(timer);
+            }}
+          }}, 60);
+        }})();
+        </script>
+        """
+    html = getattr(st, "html", None)
+    if callable(html):
+        try:
+            html(script_html, unsafe_allow_javascript=True)
+        except TypeError:
+            html(script_html)
+    else:
+        try:
+            import streamlit.components.v1 as components
+
+            components.html(script_html, height=0)
+        except Exception:
+            pass
+    st.session_state["pending_focus_key"] = ""
+    st.session_state["pending_focus_mode"] = ""
+
+
+def inject_item_enter_add_bridge() -> None:
+    script_html = """
+        <script>
+        (function() {
+          const rootDoc = (window.parent && window.parent.document) ? window.parent.document : document;
+          if (rootDoc.__rsItemEnterBridgeInstalled) return;
+          rootDoc.__rsItemEnterBridgeInstalled = true;
+
+          function findAddItemButton() {
+            const buttons = Array.from(rootDoc.querySelectorAll('button'));
+            return buttons.find((btn) => (btn.textContent || '').trim() === '+ Add Another Item');
+          }
+
+          rootDoc.addEventListener('keydown', function(e) {
+            if (e.key !== 'Enter') return;
+            const target = e.target;
+            if (!(target instanceof HTMLInputElement)) return;
+
+            const placeholder = target.getAttribute('placeholder') || '';
+            if (placeholder !== 'Enter item name') return;
+
+            e.preventDefault();
+            const addBtn = findAddItemButton();
+            if (addBtn) addBtn.click();
+          }, true);
+        })();
+        </script>
+    """
+    html = getattr(st, "html", None)
+    if callable(html):
+        try:
+            html(script_html, unsafe_allow_javascript=True)
+        except TypeError:
+            html(script_html)
+
+
+def inject_person_enter_add_bridge() -> None:
+    script_html = """
+        <script>
+        (function() {
+          const rootDoc = (window.parent && window.parent.document) ? window.parent.document : document;
+          if (rootDoc.__rsPersonEnterBridgeInstalled) return;
+          rootDoc.__rsPersonEnterBridgeInstalled = true;
+
+          function findAddPersonButton() {
+            const buttons = Array.from(rootDoc.querySelectorAll('button'));
+            return buttons.find((btn) => (btn.textContent || '').trim() === '+ Add Person');
+          }
+
+          rootDoc.addEventListener('keydown', function(e) {
+            if (e.key !== 'Enter') return;
+            const target = e.target;
+            if (!(target instanceof HTMLInputElement)) return;
+
+            const aria = target.getAttribute('aria-label') || '';
+            if (!/^Person \\d+ Name$/.test(aria)) return;
+
+            e.preventDefault();
+            const addBtn = findAddPersonButton();
+            if (addBtn) addBtn.click();
+          }, true);
+        })();
+        </script>
+    """
+    html = getattr(st, "html", None)
+    if callable(html):
+        try:
+            html(script_html, unsafe_allow_javascript=True)
+        except TypeError:
+            html(script_html)
+
+
 def init_state() -> None:
     if "people" not in st.session_state:
         st.session_state.people = create_default_people()
     if "items" not in st.session_state:
-        st.session_state.items = [create_empty_item()]
+        st.session_state["items"] = [create_empty_item()]
     if "tax_amount" not in st.session_state:
         st.session_state.tax_amount = 0.0
     if "tip_amount" not in st.session_state:
         st.session_state.tip_amount = 0.0
-    if "people_ids_key" not in st.session_state:
-        st.session_state.people_ids_key = "|".join(person.id for person in st.session_state.people)
+    if "pending_focus_key" not in st.session_state:
+        st.session_state["pending_focus_key"] = ""
+    if "pending_focus_mode" not in st.session_state:
+        st.session_state["pending_focus_mode"] = ""
 
 
-def sync_items_with_people_if_needed() -> None:
-    next_key = "|".join(person.id for person in st.session_state.people)
-    if next_key != st.session_state.people_ids_key:
-        st.session_state.items = sync_all_items_people(st.session_state.items, st.session_state.people)
-        st.session_state.people_ids_key = next_key
+def sync_items_after_people_change() -> None:
+    """Sync custom split maps when people are added/removed."""
+    st.session_state["items"] = sync_all_items_people(st.session_state["items"], st.session_state.people)
 
 
-def add_person() -> None:
+def add_person() -> str:
     next_idx = len(st.session_state.people) + 1
-    new_people = [*st.session_state.people, Person(id=generate_person_id(), name=f"Person {next_idx}")]
+    person_id = generate_person_id()
+    new_people = [*st.session_state.people, Person(id=person_id, name=f"Person {next_idx}")]
     st.session_state.people = new_people
-    sync_items_with_people_if_needed()
+    sync_items_after_people_change()
+    return person_id
 
 
 def delete_person(person_id: str) -> None:
     if len(st.session_state.people) <= 2:
         return
     st.session_state.people = [person for person in st.session_state.people if person.id != person_id]
-    st.session_state.items = [
-        replace(item, payer="" if item.payer == person_id else item.payer) for item in st.session_state.items
+    st.session_state["items"] = [
+        replace(item, payer="" if item.payer == person_id else item.payer) for item in st.session_state["items"]
     ]
-    sync_items_with_people_if_needed()
+    sync_items_after_people_change()
 
 
-def add_item() -> None:
-    st.session_state.items = [*st.session_state.items, create_empty_item()]
+def add_item() -> str:
+    item = create_empty_item()
+    st.session_state["items"] = [*st.session_state["items"], item]
+    return item.id
+
+
+def _person_name_changed(person_id: str, idx: int) -> None:
+    widget_key = f"person-name-{person_id}"
+    name = st.session_state.get(widget_key, "")
+    st.session_state.people[idx] = replace(st.session_state.people[idx], name=name)
+
+
+def _item_name_changed(item_id: str, idx: int) -> None:
+    widget_key = f"item-name-{item_id}"
+    name = st.session_state.get(widget_key, "")
+    current = st.session_state["items"][idx]
+    st.session_state["items"][idx] = replace(current, name=name)
 
 
 def remove_item(item_id: str) -> None:
-    st.session_state.items = [item for item in st.session_state.items if item.id != item_id]
-    if not st.session_state.items:
-        st.session_state.items = [create_empty_item()]
+    st.session_state["items"] = [item for item in st.session_state["items"] if item.id != item_id]
+    if not st.session_state["items"]:
+        st.session_state["items"] = [create_empty_item()]
 
 
 def render_people_section() -> None:
@@ -81,21 +419,29 @@ def render_people_section() -> None:
         add_person()
         st.rerun()
 
-    for idx, person in enumerate(st.session_state.people):
-        cols = st.columns([5, 1])
-        new_name = cols[0].text_input(
-            f"Person {idx + 1} Name",
-            value=person.name,
-            key=f"person-name-{person.id}",
-            placeholder=f"Person {idx + 1}",
-        )
-        if new_name != person.name:
-            st.session_state.people[idx] = replace(person, name=new_name)
+    people = st.session_state.people
+    for row_start in range(0, len(people), 2):
+        row_people = people[row_start : row_start + 2]
+        row_cols = st.columns(2)
+        for offset, person in enumerate(row_people):
+            global_idx = row_start + offset
+            with row_cols[offset]:
+                cols = st.columns([5, 1.4])
+                widget_key = f"person-name-{person.id}"
+                if widget_key not in st.session_state:
+                    st.session_state[widget_key] = person.name
+                cols[0].text_input(
+                    f"Person {global_idx + 1} Name",
+                    key=widget_key,
+                    placeholder=f"Person {global_idx + 1}",
+                    on_change=_person_name_changed,
+                    args=(person.id, global_idx),
+                )
 
-        can_delete = len(st.session_state.people) > 2
-        if cols[1].button("Delete", key=f"delete-person-{person.id}", disabled=not can_delete):
-            delete_person(person.id)
-            st.rerun()
+                can_delete = len(st.session_state.people) > 2
+                if cols[1].button("Delete", key=f"delete-person-{person.id}", disabled=not can_delete):
+                    delete_person(person.id)
+                    st.rerun()
 
 
 def _payer_options(people: list[Person]) -> list[tuple[str, str]]:
@@ -107,17 +453,26 @@ def _payer_options(people: list[Person]) -> list[tuple[str, str]]:
 
 def render_items_section() -> None:
     st.subheader("Add Items")
+    header = st.columns([2.8, 1.0, 1.4, 2.2, 0.8])
+    header[0].markdown("**Item Description**")
+    header[1].markdown("**Cost ($)**")
+    header[2].markdown("**Expense To**")
+    header[3].markdown("**Custom Split**")
+    header[4].markdown("**Action**")
 
-    for index, item in enumerate(st.session_state.items, start=1):
+    for index, item in enumerate(st.session_state["items"], start=1):
         with st.container(border=True):
-            st.markdown(f"**Item {index}**")
-            row1 = st.columns([3, 1.2, 1.5, 1])
-            name = row1[0].text_input(
+            row1 = st.columns([2.8, 1.0, 1.4, 2.2, 0.8])
+            name_key = f"item-name-{item.id}"
+            if name_key not in st.session_state:
+                st.session_state[name_key] = item.name
+            row1[0].text_input(
                 "Item Description",
-                value=item.name,
-                key=f"item-name-{item.id}",
+                key=name_key,
                 label_visibility="collapsed",
                 placeholder="Enter item name",
+                on_change=_item_name_changed,
+                args=(item.id, index - 1),
             )
             cost = row1[1].number_input(
                 "Cost ($)",
@@ -141,11 +496,11 @@ def render_items_section() -> None:
                 key=f"item-payer-{item.id}",
                 label_visibility="collapsed",
             )
-            if row1[3].button("Remove", key=f"remove-item-{item.id}"):
+            if row1[4].button("Remove", key=f"remove-item-{item.id}"):
                 remove_item(item.id)
                 st.rerun()
 
-            updated = replace(item, name=name, cost=cost)
+            updated = replace(item, name=st.session_state.get(name_key, item.name), cost=cost)
             if payer != item.payer:
                 if payer == "Custom":
                     updated = sync_custom_values_with_people(replace(updated, payer=payer), st.session_state.people)
@@ -155,46 +510,69 @@ def render_items_section() -> None:
                 updated = replace(updated, payer=payer)
 
             payer_invalid = bool(updated.payer) and not is_payer_valid(updated, st.session_state.people)
-            if payer_invalid:
-                st.caption("Select a valid person or split option.")
+            with row1[2]:
+                if payer_invalid:
+                    st.caption("Select a valid person or split option.")
 
             if updated.payer == "Custom":
                 custom_values = dict(updated.custom.values)
-                custom_cols = st.columns(len(st.session_state.people))
-                for col, person in zip(custom_cols, st.session_state.people):
-                    custom_values[person.id] = col.text_input(
-                        f"{person.name} % or $",
-                        value=custom_values.get(person.id, ""),
-                        key=f"custom-value-{item.id}-{person.id}",
+                with row1[3]:
+                    custom_cols = st.columns(len(st.session_state.people))
+                    for col, person in zip(custom_cols, st.session_state.people):
+                        raw_value = custom_values.get(person.id, "")
+                        try:
+                            numeric_value = float(raw_value) if raw_value != "" else 0.0
+                        except ValueError:
+                            numeric_value = 0.0
+                        entered_value = col.number_input(
+                            f"{person.name} % or $",
+                            value=numeric_value,
+                            key=f"custom-value-{item.id}-{person.id}",
+                            label_visibility="collapsed",
+                            min_value=0.0,
+                            step=0.01,
+                            format="%.2f",
+                        )
+                        custom_values[person.id] = f"{entered_value:.2f}"
+                    custom_type = st.selectbox(
+                        "Custom split type",
+                        options=["percent", "dollar"],
+                        index=0 if updated.custom.type == "percent" else 1,
+                        key=f"custom-type-{item.id}",
+                        label_visibility="collapsed",
                     )
-                custom_type = st.selectbox(
-                    "Custom split type",
-                    options=["percent", "dollar"],
-                    index=0 if updated.custom.type == "percent" else 1,
-                    key=f"custom-type-{item.id}",
-                )
-                updated = replace(updated, custom=CustomSplit(type=custom_type, values=custom_values))
+                    updated = replace(updated, custom=CustomSplit(type=custom_type, values=custom_values))
 
-                progress = get_custom_split_progress(updated, st.session_state.people, updated.cost or 0.0)
-                if progress:
-                    if progress["mode"] == "percent":
-                        st.caption(f'{progress["current"]:.1f}% of 100%')
-                    else:
-                        if progress["target"] <= 0:
-                            st.caption("Enter line cost to track dollar split")
+                    progress = get_custom_split_progress(updated, st.session_state.people, updated.cost or 0.0)
+                    if progress:
+                        if progress["mode"] == "percent":
+                            st.caption(f'Progress: {progress["current"]:.2f}% of 100%')
                         else:
-                            st.caption(f'${progress["current"]:.2f} of ${progress["target"]:.2f}')
-                    st.progress(min(max(float(progress["ratio"]), 0.0), 1.0))
+                            if progress["target"] <= 0:
+                                st.caption("Enter line cost to track dollar split")
+                            else:
+                                st.caption(
+                                    f'Progress: \\${progress["current"]:.2f} of \\${progress["target"]:.2f}'
+                                )
+                        ratio = float(progress["ratio"])
+                        clamped = min(max(ratio, 0.0), 1.0)
+                        st.progress(clamped)
+                        if ratio > 1:
+                            st.caption(f"Over-allocated by {(ratio - 1) * 100:.2f}%")
+                        elif ratio == 1:
+                            st.caption("Split complete")
+                        else:
+                            st.caption(f"{(1 - ratio) * 100:.2f}% remaining")
 
-                custom_invalid = (
-                    updated.payer == "Custom"
-                    and (updated.cost or 0.0) > 0
-                    and not is_custom_split_valid(updated, st.session_state.people, updated.cost or 0.0)
-                )
-                if custom_invalid:
-                    st.caption("Custom split must total 100% or match item cost.")
+                    custom_invalid = (
+                        updated.payer == "Custom"
+                        and (updated.cost or 0.0) > 0
+                        and not is_custom_split_valid(updated, st.session_state.people, updated.cost or 0.0)
+                    )
+                    if custom_invalid:
+                        st.caption("Custom split must total 100% or match item cost.")
 
-            st.session_state.items[index - 1] = updated
+            st.session_state["items"][index - 1] = updated
 
     if st.button("+ Add Another Item"):
         add_item()
@@ -222,29 +600,59 @@ def render_tax_tip_section() -> None:
 
 def render_summary(summary) -> None:
     st.subheader("Summary")
+    st.markdown('<div class="rs-summary-grid">', unsafe_allow_html=True)
     for idx, person in enumerate(st.session_state.people):
-        with st.container(border=True):
-            st.markdown(f"**{person.name}**")
-            st.write(f"Subtotal: {format_currency(summary.subtotals[idx])}")
-            st.write(f"Tax Share: {format_currency(summary.tax_shares[idx])}")
-            st.write(f"Tip Share: {format_currency(summary.tip_shares[idx])}")
-            st.write(f"Total: {format_currency(summary.totals[idx])}")
+        st.markdown(
+            (
+                '<div class="rs-summary-card">'
+                f"<h4>{person.name}</h4>"
+                '<div class="rs-summary-row"><span>Subtotal:</span>'
+                f"<span>{format_currency(summary.subtotals[idx])}</span></div>"
+                '<div class="rs-summary-row"><span>Tax Share:</span>'
+                f"<span>{format_currency(summary.tax_shares[idx])}</span></div>"
+                '<div class="rs-summary-row"><span>Tip Share:</span>'
+                f"<span>{format_currency(summary.tip_shares[idx])}</span></div>"
+                '<div class="rs-summary-row rs-summary-row-total"><span>Total:</span>'
+                f"<span>{format_currency(summary.totals[idx])}</span></div>"
+                "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def render_running_total(summary) -> None:
     rows = build_running_rows(
         st.session_state.people,
-        st.session_state.items,
+        st.session_state["items"],
         summary,
         st.session_state.tax_amount,
         st.session_state.tip_amount,
     )
     st.subheader("Running Total")
+    header = st.columns([2.5, 1, 1.5, 3])
+    header[0].markdown('<div class="rs-running-table-head">Item Description</div>', unsafe_allow_html=True)
+    header[1].markdown('<div class="rs-running-table-head">Cost ($)</div>', unsafe_allow_html=True)
+    header[2].markdown('<div class="rs-running-table-head">Expense To</div>', unsafe_allow_html=True)
+    header[3].markdown('<div class="rs-running-table-head">Share</div>', unsafe_allow_html=True)
+    st.divider()
     for row in rows:
+        cols = st.columns([2.5, 1, 1.5, 3])
+        if row.is_total:
+            cols[0].markdown(f'<div class="rs-running-total-row">{row.name}</div>', unsafe_allow_html=True)
+            cols[1].markdown(
+                f'<div class="rs-running-total-row">{format_currency(row.cost)}</div>', unsafe_allow_html=True
+            )
+            cols[2].markdown('<div class="rs-running-total-row">-</div>', unsafe_allow_html=True)
+        else:
+            cols[0].write(row.name)
+            cols[1].write(format_currency(row.cost))
+            cols[2].write(row.payer or "-")
         shares_text = "\n".join(f"{share.name}: {format_currency(share.amount)}" for share in row.shares)
-        st.markdown(
-            f"**{row.name}** | {format_currency(row.cost)} | {row.payer or '-'}\n\n{shares_text}"
-        )
+        if row.is_total:
+            cols[3].markdown(f'<div class="rs-running-total-row">{shares_text}</div>', unsafe_allow_html=True)
+        else:
+            cols[3].text(shares_text)
 
 
 def render_export(invalid_custom_count: int) -> None:
@@ -256,7 +664,7 @@ def render_export(invalid_custom_count: int) -> None:
 
     csv_content = build_csv_content(
         st.session_state.people,
-        st.session_state.items,
+        st.session_state["items"],
         st.session_state.tax_amount,
         st.session_state.tip_amount,
     )
@@ -267,35 +675,58 @@ def render_export(invalid_custom_count: int) -> None:
         mime="text/csv",
         disabled=invalid_custom_count > 0,
     )
+    if invalid_custom_count > 0:
+        st.markdown('<div class="rs-export-help">Fix invalid custom splits to enable download.</div>', unsafe_allow_html=True)
+    else:
+        st.markdown(
+            '<div class="rs-export-help">Click to download a CSV file that you can open in Excel</div>',
+            unsafe_allow_html=True,
+        )
 
 
 def main() -> None:
     st.set_page_config(page_title="Receipt Cost Splitter", layout="wide")
-    st.title("Receipt Cost Splitter")
-    init_state()
-    sync_items_with_people_if_needed()
+    inject_styles()
+    inject_person_enter_add_bridge()
+    inject_item_enter_add_bridge()
+    with st.container(key="rs-shell"):
+        st.title("Receipt Cost Splitter")
+        init_state()
 
-    render_people_section()
-    render_items_section()
-    render_tax_tip_section()
+        with st.container(key="rs-config-section"):
+            render_people_section()
 
-    invalid_custom_count = count_invalid_custom_items(st.session_state.items, st.session_state.people)
-    if invalid_custom_count > 0:
-        label = "item has" if invalid_custom_count == 1 else "items have"
-        st.error(
-            f"{invalid_custom_count} {label} invalid custom splits. Fix them to include them in totals. "
-            "CSV export is disabled until all custom splits are valid."
+        with st.container(key="rs-items-section"):
+            render_items_section()
+
+        with st.container(key="rs-tax-section"):
+            render_tax_tip_section()
+
+        invalid_custom_count = count_invalid_custom_items(st.session_state["items"], st.session_state.people)
+        if invalid_custom_count > 0:
+            label = "item has" if invalid_custom_count == 1 else "items have"
+            st.markdown(
+                (
+                    '<div class="rs-invalid-banner">'
+                    f"{invalid_custom_count} {label} invalid custom splits. Fix them to include them in totals. "
+                    "CSV export is disabled until all custom splits are valid."
+                    "</div>"
+                ),
+                unsafe_allow_html=True,
+            )
+
+        summary = compute_summary(
+            st.session_state.people,
+            st.session_state["items"],
+            st.session_state.tax_amount,
+            st.session_state.tip_amount,
         )
-
-    summary = compute_summary(
-        st.session_state.people,
-        st.session_state.items,
-        st.session_state.tax_amount,
-        st.session_state.tip_amount,
-    )
-    render_summary(summary)
-    render_running_total(summary)
-    render_export(invalid_custom_count)
+        render_summary(summary)
+        with st.container(key="rs-running-section"):
+            render_running_total(summary)
+        with st.container(key="rs-export-section"):
+            render_export(invalid_custom_count)
+        apply_pending_focus()
 
 
 if __name__ == "__main__":

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import streamlit as st
+
+from streamlit_domain import (
+    CustomSplit,
+    Item,
+    Person,
+    build_csv_content,
+    build_running_rows,
+    compute_summary,
+    count_invalid_custom_items,
+    create_default_people,
+    create_empty_item,
+    generate_person_id,
+    get_custom_split_progress,
+    is_custom_split_valid,
+    is_payer_valid,
+    sync_all_items_people,
+    sync_custom_values_with_people,
+)
+
+
+def format_currency(value: float) -> str:
+    return f"${value:.2f}"
+
+
+def init_state() -> None:
+    if "people" not in st.session_state:
+        st.session_state.people = create_default_people()
+    if "items" not in st.session_state:
+        st.session_state.items = [create_empty_item()]
+    if "tax_amount" not in st.session_state:
+        st.session_state.tax_amount = 0.0
+    if "tip_amount" not in st.session_state:
+        st.session_state.tip_amount = 0.0
+    if "people_ids_key" not in st.session_state:
+        st.session_state.people_ids_key = "|".join(person.id for person in st.session_state.people)
+
+
+def sync_items_with_people_if_needed() -> None:
+    next_key = "|".join(person.id for person in st.session_state.people)
+    if next_key != st.session_state.people_ids_key:
+        st.session_state.items = sync_all_items_people(st.session_state.items, st.session_state.people)
+        st.session_state.people_ids_key = next_key
+
+
+def add_person() -> None:
+    next_idx = len(st.session_state.people) + 1
+    new_people = [*st.session_state.people, Person(id=generate_person_id(), name=f"Person {next_idx}")]
+    st.session_state.people = new_people
+    sync_items_with_people_if_needed()
+
+
+def delete_person(person_id: str) -> None:
+    if len(st.session_state.people) <= 2:
+        return
+    st.session_state.people = [person for person in st.session_state.people if person.id != person_id]
+    st.session_state.items = [
+        replace(item, payer="" if item.payer == person_id else item.payer) for item in st.session_state.items
+    ]
+    sync_items_with_people_if_needed()
+
+
+def add_item() -> None:
+    st.session_state.items = [*st.session_state.items, create_empty_item()]
+
+
+def remove_item(item_id: str) -> None:
+    st.session_state.items = [item for item in st.session_state.items if item.id != item_id]
+    if not st.session_state.items:
+        st.session_state.items = [create_empty_item()]
+
+
+def render_people_section() -> None:
+    left, right = st.columns([3, 1])
+    left.subheader("Configuration")
+    if right.button("+ Add Person", use_container_width=True):
+        add_person()
+        st.rerun()
+
+    for idx, person in enumerate(st.session_state.people):
+        cols = st.columns([5, 1])
+        new_name = cols[0].text_input(
+            f"Person {idx + 1} Name",
+            value=person.name,
+            key=f"person-name-{person.id}",
+            placeholder=f"Person {idx + 1}",
+        )
+        if new_name != person.name:
+            st.session_state.people[idx] = replace(person, name=new_name)
+
+        can_delete = len(st.session_state.people) > 2
+        if cols[1].button("Delete", key=f"delete-person-{person.id}", disabled=not can_delete):
+            delete_person(person.id)
+            st.rerun()
+
+
+def _payer_options(people: list[Person]) -> list[tuple[str, str]]:
+    options = [("", "Select...")]
+    options.extend((person.id, person.name) for person in people)
+    options.extend([("Split", "Split Evenly"), ("Custom", "Custom Split")])
+    return options
+
+
+def render_items_section() -> None:
+    st.subheader("Add Items")
+
+    for index, item in enumerate(st.session_state.items, start=1):
+        with st.container(border=True):
+            st.markdown(f"**Item {index}**")
+            row1 = st.columns([3, 1.2, 1.5, 1])
+            name = row1[0].text_input(
+                "Item Description",
+                value=item.name,
+                key=f"item-name-{item.id}",
+                label_visibility="collapsed",
+                placeholder="Enter item name",
+            )
+            cost = row1[1].number_input(
+                "Cost ($)",
+                value=float(item.cost) if item.cost is not None else 0.0,
+                min_value=0.0,
+                step=0.01,
+                format="%.2f",
+                key=f"item-cost-{item.id}",
+                label_visibility="collapsed",
+            )
+
+            options = _payer_options(st.session_state.people)
+            option_values = [opt[0] for opt in options]
+            option_labels = {value: label for value, label in options}
+            current_payer = item.payer if item.payer in option_values else ""
+            payer = row1[2].selectbox(
+                "Expense To",
+                options=option_values,
+                index=option_values.index(current_payer),
+                format_func=lambda v: option_labels[v],
+                key=f"item-payer-{item.id}",
+                label_visibility="collapsed",
+            )
+            if row1[3].button("Remove", key=f"remove-item-{item.id}"):
+                remove_item(item.id)
+                st.rerun()
+
+            updated = replace(item, name=name, cost=cost)
+            if payer != item.payer:
+                if payer == "Custom":
+                    updated = sync_custom_values_with_people(replace(updated, payer=payer), st.session_state.people)
+                else:
+                    updated = replace(updated, payer=payer, custom=CustomSplit(type="percent", values={}))
+            else:
+                updated = replace(updated, payer=payer)
+
+            payer_invalid = bool(updated.payer) and not is_payer_valid(updated, st.session_state.people)
+            if payer_invalid:
+                st.caption("Select a valid person or split option.")
+
+            if updated.payer == "Custom":
+                custom_values = dict(updated.custom.values)
+                custom_cols = st.columns(len(st.session_state.people))
+                for col, person in zip(custom_cols, st.session_state.people):
+                    custom_values[person.id] = col.text_input(
+                        f"{person.name} % or $",
+                        value=custom_values.get(person.id, ""),
+                        key=f"custom-value-{item.id}-{person.id}",
+                    )
+                custom_type = st.selectbox(
+                    "Custom split type",
+                    options=["percent", "dollar"],
+                    index=0 if updated.custom.type == "percent" else 1,
+                    key=f"custom-type-{item.id}",
+                )
+                updated = replace(updated, custom=CustomSplit(type=custom_type, values=custom_values))
+
+                progress = get_custom_split_progress(updated, st.session_state.people, updated.cost or 0.0)
+                if progress:
+                    if progress["mode"] == "percent":
+                        st.caption(f'{progress["current"]:.1f}% of 100%')
+                    else:
+                        if progress["target"] <= 0:
+                            st.caption("Enter line cost to track dollar split")
+                        else:
+                            st.caption(f'${progress["current"]:.2f} of ${progress["target"]:.2f}')
+                    st.progress(min(max(float(progress["ratio"]), 0.0), 1.0))
+
+                custom_invalid = (
+                    updated.payer == "Custom"
+                    and (updated.cost or 0.0) > 0
+                    and not is_custom_split_valid(updated, st.session_state.people, updated.cost or 0.0)
+                )
+                if custom_invalid:
+                    st.caption("Custom split must total 100% or match item cost.")
+
+            st.session_state.items[index - 1] = updated
+
+    if st.button("+ Add Another Item"):
+        add_item()
+        st.rerun()
+
+
+def render_tax_tip_section() -> None:
+    st.subheader("Tax and Tip")
+    col1, col2 = st.columns(2)
+    st.session_state.tax_amount = col1.number_input(
+        "Total Tax Amount ($)",
+        value=float(st.session_state.tax_amount),
+        min_value=0.0,
+        step=0.01,
+        format="%.2f",
+    )
+    st.session_state.tip_amount = col2.number_input(
+        "Total Tip Amount ($)",
+        value=float(st.session_state.tip_amount),
+        min_value=0.0,
+        step=0.01,
+        format="%.2f",
+    )
+
+
+def render_summary(summary) -> None:
+    st.subheader("Summary")
+    for idx, person in enumerate(st.session_state.people):
+        with st.container(border=True):
+            st.markdown(f"**{person.name}**")
+            st.write(f"Subtotal: {format_currency(summary.subtotals[idx])}")
+            st.write(f"Tax Share: {format_currency(summary.tax_shares[idx])}")
+            st.write(f"Tip Share: {format_currency(summary.tip_shares[idx])}")
+            st.write(f"Total: {format_currency(summary.totals[idx])}")
+
+
+def render_running_total(summary) -> None:
+    rows = build_running_rows(
+        st.session_state.people,
+        st.session_state.items,
+        summary,
+        st.session_state.tax_amount,
+        st.session_state.tip_amount,
+    )
+    st.subheader("Running Total")
+    for row in rows:
+        shares_text = "\n".join(f"{share.name}: {format_currency(share.amount)}" for share in row.shares)
+        st.markdown(
+            f"**{row.name}** | {format_currency(row.cost)} | {row.payer or '-'}\n\n{shares_text}"
+        )
+
+
+def render_export(invalid_custom_count: int) -> None:
+    st.subheader("Export")
+    if invalid_custom_count > 0:
+        st.warning(
+            "Fix invalid custom splits to include those items in totals. CSV export is disabled until all custom splits are valid."
+        )
+
+    csv_content = build_csv_content(
+        st.session_state.people,
+        st.session_state.items,
+        st.session_state.tax_amount,
+        st.session_state.tip_amount,
+    )
+    st.download_button(
+        "Export to CSV",
+        data=csv_content,
+        file_name="grocery_split.csv",
+        mime="text/csv",
+        disabled=invalid_custom_count > 0,
+    )
+
+
+def main() -> None:
+    st.set_page_config(page_title="Receipt Cost Splitter", layout="wide")
+    st.title("Receipt Cost Splitter")
+    init_state()
+    sync_items_with_people_if_needed()
+
+    render_people_section()
+    render_items_section()
+    render_tax_tip_section()
+
+    invalid_custom_count = count_invalid_custom_items(st.session_state.items, st.session_state.people)
+    if invalid_custom_count > 0:
+        label = "item has" if invalid_custom_count == 1 else "items have"
+        st.error(
+            f"{invalid_custom_count} {label} invalid custom splits. Fix them to include them in totals. "
+            "CSV export is disabled until all custom splits are valid."
+        )
+
+    summary = compute_summary(
+        st.session_state.people,
+        st.session_state.items,
+        st.session_state.tax_amount,
+        st.session_state.tip_amount,
+    )
+    render_summary(summary)
+    render_running_total(summary)
+    render_export(invalid_custom_count)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/streamlit_domain/__init__.py
+++ b/app/streamlit_domain/__init__.py
@@ -1,0 +1,48 @@
+from .csv_export import build_csv_content
+from .models import CustomSplit, Item, Person, RunningRow, RunningRowShare, SummaryResult
+from .running import build_running_rows
+from .splits import (
+    allocate_tax_tip,
+    compute_shares_for_item,
+    compute_subtotals,
+    compute_summary,
+    count_invalid_custom_items,
+    even_split_shares,
+    get_custom_split_progress,
+    is_custom_split_valid,
+    is_payer_valid,
+)
+from .state_helpers import (
+    create_default_people,
+    create_empty_item,
+    generate_item_id,
+    generate_person_id,
+    sync_all_items_people,
+    sync_custom_values_with_people,
+)
+
+__all__ = [
+    "CustomSplit",
+    "Item",
+    "Person",
+    "RunningRow",
+    "RunningRowShare",
+    "SummaryResult",
+    "allocate_tax_tip",
+    "build_csv_content",
+    "build_running_rows",
+    "compute_shares_for_item",
+    "compute_subtotals",
+    "compute_summary",
+    "count_invalid_custom_items",
+    "create_default_people",
+    "create_empty_item",
+    "even_split_shares",
+    "generate_item_id",
+    "generate_person_id",
+    "get_custom_split_progress",
+    "is_custom_split_valid",
+    "is_payer_valid",
+    "sync_all_items_people",
+    "sync_custom_values_with_people",
+]

--- a/app/streamlit_domain/csv_export.py
+++ b/app/streamlit_domain/csv_export.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import csv
+import io
+
+from .models import Item, Person
+from .splits import compute_shares_for_item, compute_summary
+
+
+def _expense_to_label(item: Item, people: list[Person]) -> str:
+    payer_idx = next((i for i, person in enumerate(people) if person.id == item.payer), -1)
+    if payer_idx >= 0:
+        return people[payer_idx].name
+    if item.payer == "Split":
+        return "Split Evenly"
+    if item.payer == "Custom":
+        return "Custom Split"
+    return item.payer or ""
+
+
+def build_csv_content(
+    people: list[Person], items: list[Item], tax_amount: float, tip_amount: float
+) -> str:
+    summary = compute_summary(people, items, tax_amount, tip_amount)
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, quoting=csv.QUOTE_ALL, lineterminator="\n")
+
+    writer.writerow(["Item", "Cost", "Expense To", *[f"{person.name} Share" for person in people]])
+
+    for item in items:
+        cost = item.cost or 0.0
+        shares, _ = compute_shares_for_item(item, people)
+        writer.writerow(
+            [
+                item.name.strip() or "Unnamed Item",
+                f"{cost:.2f}",
+                _expense_to_label(item, people),
+                *[f"{share:.2f}" for share in shares],
+            ]
+        )
+
+    writer.writerow(["Tax", f"{tax_amount:.2f}", "Split by ratio", *[f"{v:.2f}" for v in summary.tax_shares]])
+    writer.writerow(["Tip", f"{tip_amount:.2f}", "Split by ratio", *[f"{v:.2f}" for v in summary.tip_shares]])
+    writer.writerow([])
+    writer.writerow(["TOTALS", "", "", *[f"${total:.2f}" for total in summary.totals]])
+
+    return buffer.getvalue()

--- a/app/streamlit_domain/math_utils.py
+++ b/app/streamlit_domain/math_utils.py
@@ -1,0 +1,6 @@
+def round2(value: float) -> float:
+    return round(value * 100) / 100
+
+
+def dollars_to_cents(value: float) -> int:
+    return round(value * 100)

--- a/app/streamlit_domain/models.py
+++ b/app/streamlit_domain/models.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+CustomSplitType = Literal["percent", "dollar"]
+
+
+@dataclass
+class Person:
+    id: str
+    name: str
+
+
+@dataclass
+class CustomSplit:
+    type: CustomSplitType = "percent"
+    values: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Item:
+    id: str
+    name: str = ""
+    cost: float | None = None
+    payer: str = ""
+    custom: CustomSplit = field(default_factory=CustomSplit)
+
+
+@dataclass
+class SummaryResult:
+    subtotals: list[float]
+    tax_shares: list[float]
+    tip_shares: list[float]
+    totals: list[float]
+
+
+@dataclass
+class RunningRowShare:
+    name: str
+    amount: float
+
+
+@dataclass
+class RunningRow:
+    name: str
+    cost: float
+    payer: str
+    shares: list[RunningRowShare]
+    is_total: bool = False

--- a/app/streamlit_domain/running.py
+++ b/app/streamlit_domain/running.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from .math_utils import round2
+from .models import Item, Person, RunningRow, RunningRowShare, SummaryResult
+from .splits import compute_shares_for_item
+
+
+def build_running_rows(
+    people: list[Person],
+    items: list[Item],
+    summary: SummaryResult,
+    tax_amount: float,
+    tip_amount: float,
+) -> list[RunningRow]:
+    rows: list[RunningRow] = []
+
+    for item in items:
+        cost = item.cost or 0.0
+        if cost <= 0:
+            continue
+        shares, payer_display = compute_shares_for_item(item, people)
+        rows.append(
+            RunningRow(
+                name=item.name.strip() or "Unnamed Item",
+                cost=cost,
+                payer=payer_display,
+                shares=[
+                    RunningRowShare(name=person.name, amount=shares[idx])
+                    for idx, person in enumerate(people)
+                ],
+            )
+        )
+
+    if tax_amount > 0:
+        rows.append(
+            RunningRow(
+                name="Tax",
+                cost=tax_amount,
+                payer="Split by ratio",
+                shares=[
+                    RunningRowShare(name=person.name, amount=summary.tax_shares[idx])
+                    for idx, person in enumerate(people)
+                ],
+            )
+        )
+
+    if tip_amount > 0:
+        rows.append(
+            RunningRow(
+                name="Tip",
+                cost=tip_amount,
+                payer="Split by ratio",
+                shares=[
+                    RunningRowShare(name=person.name, amount=summary.tip_shares[idx])
+                    for idx, person in enumerate(people)
+                ],
+            )
+        )
+
+    grand_total = round2(sum(summary.totals))
+    rows.append(
+        RunningRow(
+            name="TOTAL",
+            cost=grand_total,
+            payer="",
+            shares=[
+                RunningRowShare(name=person.name, amount=summary.totals[idx])
+                for idx, person in enumerate(people)
+            ],
+            is_total=True,
+        )
+    )
+
+    return rows

--- a/app/streamlit_domain/splits.py
+++ b/app/streamlit_domain/splits.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from .math_utils import dollars_to_cents, round2
 from .models import Item, Person, SummaryResult
 
@@ -19,8 +21,9 @@ def _sum_custom_dollar_inputs_cents(values: list[float]) -> int:
     return sum(dollars_to_cents(v) for v in values)
 
 
-def _sum_custom_percent_basis_points(values: list[float]) -> int:
-    return round(sum(values) * 100)
+PERCENT_TARGET = 100.0
+# Keep tiny epsilon for float math while allowing arbitrary decimal precision.
+PERCENT_TOLERANCE = 1e-9
 
 
 def even_split_shares(cost: float, n_people: int) -> list[float]:
@@ -60,7 +63,7 @@ def is_custom_split_valid(item: Item, people: list[Person], cost: float) -> bool
         return True
     values = _parse_custom_values(item, people)
     if item.custom.type == "percent":
-        return _sum_custom_percent_basis_points(values) == 10_000
+        return math.isclose(sum(values), PERCENT_TARGET, rel_tol=0.0, abs_tol=PERCENT_TOLERANCE)
     if item.custom.type == "dollar":
         return _sum_custom_dollar_inputs_cents(values) == dollars_to_cents(cost)
     return True

--- a/app/streamlit_domain/splits.py
+++ b/app/streamlit_domain/splits.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from .math_utils import dollars_to_cents, round2
+from .models import Item, Person, SummaryResult
+
+
+def _parse_custom_values(item: Item, people: list[Person]) -> list[float]:
+    parsed: list[float] = []
+    for person in people:
+        raw = item.custom.values.get(person.id, "")
+        try:
+            parsed.append(float(raw) if raw != "" else 0.0)
+        except ValueError:
+            parsed.append(0.0)
+    return parsed
+
+
+def _sum_custom_dollar_inputs_cents(values: list[float]) -> int:
+    return sum(dollars_to_cents(v) for v in values)
+
+
+def _sum_custom_percent_basis_points(values: list[float]) -> int:
+    return round(sum(values) * 100)
+
+
+def even_split_shares(cost: float, n_people: int) -> list[float]:
+    if n_people <= 0:
+        return []
+    even_share = (cost / n_people * 100 // 1) / 100
+    distributed = even_share * n_people
+    remainder = round2(cost - distributed)
+    shares = [even_share for _ in range(n_people)]
+    if remainder != 0:
+        shares[-1] = round2(shares[-1] + remainder)
+    return shares
+
+
+def get_custom_split_progress(item: Item, people: list[Person], cost: float) -> dict | None:
+    if item.payer != "Custom":
+        return None
+    values = _parse_custom_values(item, people)
+    if item.custom.type == "percent":
+        current = sum(values)
+        return {"current": current, "target": 100.0, "mode": "percent", "ratio": current / 100.0}
+    if item.custom.type == "dollar":
+        sum_cents = _sum_custom_dollar_inputs_cents(values)
+        sum_dollars = sum_cents / 100
+        if cost <= 0:
+            return {"current": sum_dollars, "target": 0.0, "mode": "dollar", "ratio": 0.0}
+        cost_cents = dollars_to_cents(cost)
+        ratio = (sum_cents / cost_cents) if cost_cents > 0 else 0.0
+        return {"current": sum_dollars, "target": cost, "mode": "dollar", "ratio": ratio}
+    return None
+
+
+def is_custom_split_valid(item: Item, people: list[Person], cost: float) -> bool:
+    if item.payer != "Custom":
+        return True
+    if cost <= 0:
+        return True
+    values = _parse_custom_values(item, people)
+    if item.custom.type == "percent":
+        return _sum_custom_percent_basis_points(values) == 10_000
+    if item.custom.type == "dollar":
+        return _sum_custom_dollar_inputs_cents(values) == dollars_to_cents(cost)
+    return True
+
+
+def is_payer_valid(item: Item, people: list[Person]) -> bool:
+    if not item.payer:
+        return False
+    ids = {person.id for person in people}
+    return item.payer in ids or item.payer in {"Split", "Custom"}
+
+
+def compute_subtotals(people: list[Person], items: list[Item]) -> list[float]:
+    subtotals = [0.0 for _ in people]
+
+    for item in items:
+        cost = item.cost or 0.0
+        if not item.payer:
+            continue
+
+        payer_idx = next((i for i, person in enumerate(people) if person.id == item.payer), -1)
+        if payer_idx >= 0:
+            subtotals[payer_idx] += cost
+        elif item.payer == "Split":
+            shares = even_split_shares(cost, len(people))
+            for i in range(len(people)):
+                subtotals[i] += shares[i]
+        elif item.payer == "Custom" and is_custom_split_valid(item, people, cost):
+            values = _parse_custom_values(item, people)
+            if item.custom.type == "percent":
+                for i in range(len(people)):
+                    subtotals[i] += cost * (values[i] / 100)
+            elif item.custom.type == "dollar":
+                for i in range(len(people)):
+                    subtotals[i] += values[i]
+
+    return [round2(value) for value in subtotals]
+
+
+def allocate_tax_tip(
+    rounded_subtotals: list[float], tax_amount: float, tip_amount: float
+) -> tuple[list[float], list[float]]:
+    n_people = len(rounded_subtotals)
+    tax_shares = [0.0 for _ in range(n_people)]
+    tip_shares = [0.0 for _ in range(n_people)]
+    total_subtotal = sum(rounded_subtotals)
+
+    if total_subtotal > 0 and n_people > 0:
+        distributed = 0.0
+        for i in range(n_people - 1):
+            tax_shares[i] = round2((rounded_subtotals[i] / total_subtotal) * tax_amount)
+            distributed += tax_shares[i]
+        tax_shares[-1] = round2(tax_amount - distributed)
+
+        distributed = 0.0
+        for i in range(n_people - 1):
+            tip_shares[i] = round2((rounded_subtotals[i] / total_subtotal) * tip_amount)
+            distributed += tip_shares[i]
+        tip_shares[-1] = round2(tip_amount - distributed)
+
+    return tax_shares, tip_shares
+
+
+def compute_summary(
+    people: list[Person], items: list[Item], tax_amount_raw: float, tip_amount_raw: float
+) -> SummaryResult:
+    rounded_subtotals = compute_subtotals(people, items)
+    tax_amount = tax_amount_raw or 0.0
+    tip_amount = tip_amount_raw or 0.0
+    tax_shares, tip_shares = allocate_tax_tip(rounded_subtotals, tax_amount, tip_amount)
+    totals = [
+        round2(subtotal + tax_shares[idx] + tip_shares[idx])
+        for idx, subtotal in enumerate(rounded_subtotals)
+    ]
+    return SummaryResult(
+        subtotals=rounded_subtotals,
+        tax_shares=tax_shares,
+        tip_shares=tip_shares,
+        totals=totals,
+    )
+
+
+def compute_shares_for_item(item: Item, people: list[Person]) -> tuple[list[float], str]:
+    cost = item.cost or 0.0
+    shares = [0.0 for _ in people]
+    payer_display = ""
+
+    payer_idx = next((i for i, person in enumerate(people) if person.id == item.payer), -1)
+    if payer_idx >= 0:
+        shares[payer_idx] = cost
+        payer_display = people[payer_idx].name
+    elif item.payer == "Split":
+        even_shares = even_split_shares(cost, len(people))
+        for i in range(len(people)):
+            shares[i] = even_shares[i]
+        payer_display = "Split Evenly"
+    elif item.payer == "Custom":
+        payer_display = "Custom Split"
+        if is_custom_split_valid(item, people, cost):
+            values = _parse_custom_values(item, people)
+            if item.custom.type == "percent":
+                for i in range(len(people)):
+                    shares[i] = cost * (values[i] / 100)
+            elif item.custom.type == "dollar":
+                for i in range(len(people)):
+                    shares[i] = values[i]
+    else:
+        payer_display = item.payer or ""
+
+    return shares, payer_display
+
+
+def count_invalid_custom_items(items: list[Item], people: list[Person]) -> int:
+    total = 0
+    for item in items:
+        if item.payer != "Custom":
+            continue
+        cost = item.cost or 0.0
+        if cost <= 0:
+            continue
+        if not is_custom_split_valid(item, people, cost):
+            total += 1
+    return total

--- a/app/streamlit_domain/state_helpers.py
+++ b/app/streamlit_domain/state_helpers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from .models import CustomSplit, Item, Person
+
+
+def generate_person_id() -> str:
+    return f"person-{uuid4()}"
+
+
+def generate_item_id() -> str:
+    return f"item-{uuid4()}"
+
+
+def create_default_people() -> list[Person]:
+    return [
+        Person(id=generate_person_id(), name="Person 1"),
+        Person(id=generate_person_id(), name="Person 2"),
+    ]
+
+
+def create_empty_item() -> Item:
+    return Item(id=generate_item_id(), custom=CustomSplit(type="percent", values={}))
+
+
+def sync_custom_values_with_people(item: Item, people: list[Person]) -> Item:
+    values = {person.id: item.custom.values.get(person.id, "") for person in people}
+    return Item(
+        id=item.id,
+        name=item.name,
+        cost=item.cost,
+        payer=item.payer,
+        custom=CustomSplit(type=item.custom.type, values=values),
+    )
+
+
+def sync_all_items_people(items: list[Item], people: list[Person]) -> list[Item]:
+    return [sync_custom_values_with_people(item, people) for item in items]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parents[1]
+if str(APP_DIR) not in sys.path:
+    sys.path.insert(0, str(APP_DIR))

--- a/app/tests/test_csv_export.py
+++ b/app/tests/test_csv_export.py
@@ -1,0 +1,10 @@
+from streamlit_domain.csv_export import build_csv_content
+from streamlit_domain.models import CustomSplit, Item, Person
+
+
+def test_build_csv_content_escapes_quotes() -> None:
+    people = [Person(id="a", name='A"lice'), Person(id="b", name="Bob")]
+    items = [Item(id="1", name='Item "quoted"', cost=1.5, payer="a", custom=CustomSplit(values={}))]
+    csv = build_csv_content(people, items, 0, 0)
+    assert '""' in csv
+    assert len(csv.split("\n")) > 3

--- a/app/tests/test_running.py
+++ b/app/tests/test_running.py
@@ -1,0 +1,22 @@
+from streamlit_domain.models import CustomSplit, Item, Person, SummaryResult
+from streamlit_domain.running import build_running_rows
+
+
+def test_build_running_rows_includes_tax_tip_and_total() -> None:
+    people = [Person(id="a", name="Alice"), Person(id="b", name="Bob")]
+    items = [Item(id="1", name="Food", cost=10, payer="Split", custom=CustomSplit(values={}))]
+    summary = SummaryResult(
+        subtotals=[5.0, 5.0],
+        tax_shares=[0.5, 0.5],
+        tip_shares=[0.4, 0.4],
+        totals=[5.9, 5.9],
+    )
+
+    rows = build_running_rows(people, items, summary, tax_amount=1.0, tip_amount=0.8)
+
+    assert rows[0].name == "Food"
+    assert rows[1].name == "Tax"
+    assert rows[2].name == "Tip"
+    assert rows[-1].name == "TOTAL"
+    assert rows[-1].is_total is True
+    assert rows[-1].cost == 11.8

--- a/app/tests/test_splits.py
+++ b/app/tests/test_splits.py
@@ -121,6 +121,20 @@ def test_get_custom_split_progress_percent() -> None:
     assert progress["ratio"] == 0.75
 
 
+def test_custom_percent_validation_allows_high_precision_values() -> None:
+    item = Item(
+        id="1",
+        name="x",
+        cost=100,
+        payer="Custom",
+        custom=CustomSplit(
+            type="percent",
+            values={"a": "33.333333", "b": "66.666667"},
+        ),
+    )
+    assert is_custom_split_valid(item, two_people, 100) is True
+
+
 def test_dollars_to_cents_parity() -> None:
     assert dollars_to_cents(5.0) + dollars_to_cents(4.99) == 999
     assert dollars_to_cents(10.0) == 1000

--- a/app/tests/test_splits.py
+++ b/app/tests/test_splits.py
@@ -1,0 +1,126 @@
+from streamlit_domain.math_utils import dollars_to_cents
+from streamlit_domain.models import CustomSplit, Item, Person
+from streamlit_domain.splits import (
+    allocate_tax_tip,
+    compute_shares_for_item,
+    compute_subtotals,
+    compute_summary,
+    count_invalid_custom_items,
+    even_split_shares,
+    get_custom_split_progress,
+    is_custom_split_valid,
+)
+
+
+alice = Person(id="a", name="Alice")
+bob = Person(id="b", name="Bob")
+two_people = [alice, bob]
+
+
+def test_even_split_shares_remainder_last_person() -> None:
+    shares = even_split_shares(10.01, 2)
+    assert round(shares[0] + shares[1], 5) == 10.01
+    assert shares[0] == 5.00
+    assert round(shares[1], 5) == 5.01
+
+
+def test_compute_subtotals_custom_percent_valid() -> None:
+    items = [
+        Item(
+            id="1",
+            name="x",
+            cost=100,
+            payer="Custom",
+            custom=CustomSplit(type="percent", values={"a": "60", "b": "40"}),
+        )
+    ]
+    assert compute_subtotals(two_people, items) == [60.0, 40.0]
+
+
+def test_compute_subtotals_omit_invalid_custom() -> None:
+    items = [
+        Item(
+            id="1",
+            name="x",
+            cost=100,
+            payer="Custom",
+            custom=CustomSplit(type="percent", values={"a": "50", "b": "40"}),
+        )
+    ]
+    assert compute_subtotals(two_people, items) == [0.0, 0.0]
+
+
+def test_allocate_tax_tip_ratio_last_gets_remainder() -> None:
+    tax_shares, tip_shares = allocate_tax_tip([30, 70], 10, 5)
+    assert round(sum(tax_shares), 5) == 10
+    assert round(sum(tip_shares), 5) == 5
+
+
+def test_compute_summary_totals_balance() -> None:
+    items = [Item(id="1", name="Food", cost=50, payer="Split", custom=CustomSplit(values={}))]
+    summary = compute_summary(two_people, items, 5, 3)
+    assert round(summary.totals[0] + summary.totals[1], 5) == 58
+
+
+def test_custom_dollar_validation_off_by_one_cent_invalid() -> None:
+    item = Item(
+        id="1",
+        name="x",
+        cost=10,
+        payer="Custom",
+        custom=CustomSplit(type="dollar", values={"a": "5.00", "b": "4.99"}),
+    )
+    assert is_custom_split_valid(item, two_people, 10) is False
+
+
+def test_count_invalid_custom_items() -> None:
+    items = [
+        Item(
+            id="1",
+            name="bad",
+            cost=10,
+            payer="Custom",
+            custom=CustomSplit(type="percent", values={"a": "50", "b": "40"}),
+        ),
+        Item(
+            id="2",
+            name="ok",
+            cost=10,
+            payer="Custom",
+            custom=CustomSplit(type="percent", values={"a": "50", "b": "50"}),
+        ),
+    ]
+    assert count_invalid_custom_items(items, two_people) == 1
+
+
+def test_compute_shares_for_item_invalid_custom_is_zero() -> None:
+    item = Item(
+        id="1",
+        name="x",
+        cost=10,
+        payer="Custom",
+        custom=CustomSplit(type="percent", values={"a": "10", "b": "10"}),
+    )
+    shares, _ = compute_shares_for_item(item, two_people)
+    assert all(share == 0 for share in shares)
+
+
+def test_get_custom_split_progress_percent() -> None:
+    item = Item(
+        id="1",
+        name="x",
+        cost=50,
+        payer="Custom",
+        custom=CustomSplit(type="percent", values={"a": "50", "b": "25"}),
+    )
+    progress = get_custom_split_progress(item, two_people, 50)
+    assert progress is not None
+    assert progress["mode"] == "percent"
+    assert progress["current"] == 75
+    assert progress["target"] == 100
+    assert progress["ratio"] == 0.75
+
+
+def test_dollars_to_cents_parity() -> None:
+    assert dollars_to_cents(5.0) + dollars_to_cents(4.99) == 999
+    assert dollars_to_cents(10.0) == 1000


### PR DESCRIPTION
## Summary
- migrate the React/Vite receipt splitter UI to a Python Streamlit app while preserving core split logic behavior
- add a dedicated Python domain layer for calculations, running totals, state helpers, and CSV export plus pytest parity tests
- implement Streamlit UX parity work (section styling, validation messaging, custom split progress, keyboard add flows, and focus handling)

## Test plan
- [x] `python3 -m py_compile app/streamlit_app.py`
- [x] `python3 -m pytest app/tests`
- [x] manually validate add/remove people and items, custom split validation, and CSV export enable/disable behavior

Made with [Cursor](https://cursor.com)